### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.angelfish.json
+++ b/org.kde.angelfish.json
@@ -25,6 +25,9 @@
         "/lib/x86_64-linux-gnu/cmake",
         "/lib/x86_64-linux-gnu/pkgconfig"
     ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],


### PR DESCRIPTION
The installed size reduced from 310.0 MB to 303.0 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.